### PR TITLE
ci: build-test ワークフローで main を除外

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,8 @@ run-name: >
 
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths:
       - 'build/**'
       - '.github/workflows/build-test.yml'


### PR DESCRIPTION
概要
- build-test ワークフローで main ブランチへの push を除外

変更内容
- branches-ignore に main を追加
- build 関連の変更時のみ意図したブランチで実行されるよう調整