### PR TITLE
ci: シークレットのartifact受け渡しを廃止して漏えいリスクを低減

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -49,37 +49,8 @@ jobs:
       target_value: '1'      # Monday
       timezone: 'Asia/Tokyo'
 
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  # if: github.event_name == 'push' || github.event_name == 'pull_request'
-  # secrets.envファイルを作成
-  create-secrets:
-    needs: [info, check-day]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Create secrets.env file
-        run: |
-          # 環境変数経由でファイル作成（ログに表示されない）
-          cat << EOF > build/secrets.env
-          P4USER=${P4USER}
-          P4PASSWD=${P4PASSWD}
-          IMAGE_NAME=${IMAGE_NAME}
-          EOF
-          echo "secrets.env ファイルを安全に作成しました"
-        env:
-          P4USER: ${{ secrets.P4USER || 'defaultuser' }}
-          P4PASSWD: ${{ secrets.P4PASSWD || 'defaultpass' }}
-          IMAGE_NAME: ${{ secrets.IMAGE_NAME || 'helix-p4d-test' }}
-      - name: Upload secrets.env as artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: secrets-env
-          path: build/secrets.env
-          retention-days: 1
-
   test:
-    needs: [info, check-day, create-secrets]
+    needs: [info, check-day]
     uses: ./.github/workflows/test.yml
     with:
       # スケジュール実行時はDockerfile、手動実行時は選択されたファイルを使用

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,12 +43,6 @@ jobs:
         run: |
           DOCKERFILE_NAME="${{ inputs.dockerfile || 'Dockerfile' }}"
           echo "Building Docker image with $DOCKERFILE_NAME..."
-          # secrets.envファイルを安全に作成
-          cat << EOF > build/secrets.env
-          P4USER=${P4USER}
-          P4PASSWD=${P4PASSWD}
-          IMAGE_NAME=${IMAGE_NAME}
-          EOF
           bash ./build/docker-build.sh "$DOCKERFILE_NAME" ./build
         env:
           P4USER: ${{ secrets.P4USER || 'defaultuser' }}
@@ -70,11 +64,14 @@ jobs:
           
           # P4Dバージョン取得テスト
           echo "P4Dバージョン取得テスト..."
-          if P4D_VERSION=$(docker run --rm ${{ secrets.IMAGE_NAME }} p4d -V 2>/dev/null); then
+            P4D_VERSION=$(docker run --rm ${{ secrets.IMAGE_NAME }} p4d -V 2>&1 || true)
+            if echo "$P4D_VERSION" | grep -q '^Rev\.'; then
               echo "P4Dバージョン取得: 成功"
               echo "   バージョン情報: $(echo "$P4D_VERSION" | head -1)"
           else
               echo "P4Dバージョン取得: 失敗"
+              echo "=== p4d -V 出力 ==="
+              echo "$P4D_VERSION"
               exit 1
           fi
           

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -19,7 +19,7 @@ jobs:
       version_raw: ${{ steps.p4d-version.outputs.raw_version }}
     steps:
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: docker-image-${{ secrets.IMAGE_NAME }}
       - name: Load Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: docker-image-${{ secrets.IMAGE_NAME }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download secrets.env
-        uses: actions/download-artifact@v5
-        with:
-          name: secrets-env
-          path: build/
-
       - name: Build image
         run: |
           echo "Building Docker image with ${{ inputs.docker_files_name }}..."
           bash ./build/docker-build.sh "${{ inputs.docker_files_name }}" ./build
+        env:
+          P4USER: ${{ secrets.P4USER || 'defaultuser' }}
+          P4PASSWD: ${{ secrets.P4PASSWD || 'defaultpass' }}
+          IMAGE_NAME: ${{ secrets.IMAGE_NAME || 'helix-p4d-test' }}
 
       - name: Run tests
         run: |

--- a/build/docker-build.sh
+++ b/build/docker-build.sh
@@ -9,7 +9,7 @@ IMAGE_NAME="${IMAGE_NAME:-helix-p4d-test}"
 
 echo "Building Docker image with $DOCKERFILE_NAME..."
 
-# .envファイルとsecrets.envファイルの読み込みと--build-arg生成
+# .envファイルと環境変数の読み込みで--build-arg生成
 BUILD_ARGS=""
 
 # 通常の.envファイルを読み込み
@@ -24,38 +24,13 @@ if [ -f "$ENV_PATH" ]; then
     done < "$ENV_PATH"
 fi
 
-# secrets.envファイルがあれば読み込み（機密情報用）
-SECRETS_ENV_PATH="$BUILD_PATH/secrets.env"
-if [ -f "$SECRETS_ENV_PATH" ]; then
-    echo "DEBUG: secrets.envファイルが見つかりました: $SECRETS_ENV_PATH"
-    echo "DEBUG: secrets.envの内容:"
-    cat "$SECRETS_ENV_PATH"
-    echo "DEBUG: secrets.envファイル読み込み開始"
-    
-    while IFS='=' read -r key value; do
-        echo "DEBUG: 読み込み行: key='$key' value='$value'"
-        # コメント・空行・export除外
-        if [[ "$key" =~ ^# ]] || [[ -z "$key" ]]; then 
-            echo "DEBUG: スキップ（コメントまたは空行）"
-            continue
-        fi
-        key=$(echo "$key" | sed 's/^export //')
-        value=$(echo "$value" | sed 's/^\s*//;s/\s*$//')
-        echo "DEBUG: 処理後: key='$key' value='$value'"
-        
-        # IMAGE_NAMEの場合は環境変数も更新
-        if [ "$key" = "IMAGE_NAME" ]; then
-            IMAGE_NAME="$value"
-            echo "DEBUG: IMAGE_NAMEを更新しました: $IMAGE_NAME"
-        fi
-        
-        # 空の値でも--build-argとして渡す（Dockerfile側でデフォルト値を設定）
+# CIなどで渡された環境変数をbuild-argへ反映（値はログ出力しない）
+for key in P4NAME P4PORT P4USER P4PASSWD P4HOME P4ROOT CASE_INSENSITIVE; do
+    value="${!key}"
+    if [ -n "$value" ]; then
         BUILD_ARGS+=" --build-arg $key=$value"
-    done < "$SECRETS_ENV_PATH"
-    echo "DEBUG: secrets.envファイル読み込み完了"
-else
-    echo "DEBUG: secrets.envファイルが見つかりません: $SECRETS_ENV_PATH"
-fi
+    fi
+done
 
 echo "Building Docker image with $DOCKERFILE_NAME..."
 docker build -t "$IMAGE_NAME" $BUILD_ARGS $EXTRA_ARGS -f "$BUILD_PATH/$DOCKERFILE_NAME" "$BUILD_PATH"


### PR DESCRIPTION
## 概要
GitHub Actions で `secrets.env` をファイル化して artifact 経由で受け渡ししていた経路を廃止し、シークレット露出リスクを下げる改修です。

## 変更内容
- `build-develop.yml`
  - `create-secrets` ジョブを削除
  - `test` ジョブ依存を `info, check-day` のみに変更
- `test.yml`
  - `secrets-env` artifact のダウンロードを削除
  - `Build image` ステップに `env` で必要値を直接注入
- `build-test.yml`
  - `secrets.env` 生成処理を削除
- `build/docker-build.sh`
  - `secrets.env` 読み込みとデバッグ出力を削除
  - `env` から build-arg を構成する方式へ変更
- `build/Dockerfile`
  - `P4PASSWD` の ARG/ENV を削除（イメージ固定化回避）

## 期待効果
- 平文シークレットファイルの artifact 保存を撤廃
- ログ経由のシークレット露出リスクを低減
- ワークフロー間のシークレット受け渡しを簡素化

## 注意
このPRは `feature/remove-secrets-artifact` ブランチの現時点の内容を対象としています。