### PR TITLE
ci: check-day の再利用workflow参照を utils に変更

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -43,7 +43,7 @@ jobs:
   # Uses external reusable workflow for day checking logic
   check-day:
     needs: info
-    uses: radicalgrimoire/github-actions-utils/.github/workflows/check-schedule-day.yml@main
+    uses: radicalgrimoire/utils/.github/workflows/check-schedule-day.yml@main
     with:
       schedule_type: 'weekly'
       target_value: '1'      # Monday


### PR DESCRIPTION
## 概要
- build-develop の check-day 参照先を新リポジトリへ変更

## 変更内容
- radicalgrimoire/github-actions-utils/.github/workflows/check-schedule-day.yml@main
- → radicalgrimoire/utils/.github/workflows/check-schedule-day.yml@main

## 影響範囲
- .github/workflows/build-develop.yml の check-day ジョブのみ

## 確認
- 既存のジョブ構成・条件分岐は変更なし