### PR TITLE
ci: build-develop の check-day 参照先を更新

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -43,7 +43,7 @@ jobs:
   # Uses external reusable workflow for day checking logic
   check-day:
     needs: info
-    uses: radicalgrimoire/utils/.github/workflows/check-schedule-day.yml@main
+    uses: radicalgrimoire/utils/.github/workflows/check-day.yml@main
     with:
       schedule_type: 'weekly'
       target_value: '1'      # Monday


### PR DESCRIPTION
## 概要
- build-develop の日付チェック用 reusable workflow 参照先を更新
- utils 側の rename に追従

## 変更内容
- .github/workflows/build-develop.yml
  - radicalgrimoire/utils/.github/workflows/check-schedule-day.yml@main
  - -> radicalgrimoire/utils/.github/workflows/check-day.yml@main

## 影響範囲
- build-develop ワークフローの check-day ジョブのみ

## 確認
- YAML 構文エラーなし