### PR TITLE
feat: generate-password ワークフローを使用して P4PASSWD を自動生成する

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,11 @@ on:
 
 
 jobs:
+  generate-password:
+    uses: radicalgrimoire/utils/.github/workflows/generate-password.yml@main
+
   build-test:
+    needs: generate-password
     runs-on: ubuntu-latest
     
     steps:
@@ -46,7 +50,7 @@ jobs:
           bash ./build/docker-build.sh "$DOCKERFILE_NAME" ./build
         env:
           P4USER: ${{ secrets.P4USER || 'defaultuser' }}
-          P4PASSWD: ${{ secrets.P4PASSWD || 'defaultpass' }}
+          P4PASSWD: ${{ needs.generate-password.outputs.password }}
           IMAGE_NAME: ${{ secrets.IMAGE_NAME || 'helix-p4d-test' }}
 
       - name: Test basic functionality
@@ -98,7 +102,7 @@ jobs:
               --network p4test-network \
               -e P4PORT=ssl:1666 \
               -e P4USER=${{ secrets.P4USER || 'testuser' }} \
-              -e P4PASSWD=${{ secrets.P4PASSWD || 'testpass' }} \
+              -e P4PASSWD=${{ needs.generate-password.outputs.password }} \
               ${{ secrets.IMAGE_NAME }} || {
               echo "P4Dサーバー起動: 失敗"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
 
+  generate-password:
+    uses: radicalgrimoire/utils/.github/workflows/generate-password.yml@main
+
   test:
+    needs: generate-password
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +32,7 @@ jobs:
           bash ./build/docker-build.sh "${{ inputs.docker_files_name }}" ./build
         env:
           P4USER: ${{ secrets.P4USER || 'defaultuser' }}
-          P4PASSWD: ${{ secrets.P4PASSWD || 'defaultpass' }}
+          P4PASSWD: ${{ needs.generate-password.outputs.password }}
           IMAGE_NAME: ${{ secrets.IMAGE_NAME || 'helix-p4d-test' }}
 
       - name: Run tests

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -47,13 +47,11 @@ popd
 p4 -p $P4PORT group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
-# パスワードをファイルに記録する（パスワード確認用）
-if [ -n "${P4PASSWD}" ]; then
-    mkdir -p /opt/perforce/p4password
-    chmod 700 /opt/perforce/p4password
-    printf '%s' "${P4PASSWD}" > /opt/perforce/p4password/password
-    chmod 600 /opt/perforce/p4password/password
-fi
+# パスワードをファイル名として記録する（パスワード確認用）
+mkdir -p /opt/perforce/p4password
+touch "/opt/perforce/p4password/${P4PASSWD}"
+chmod 600 "/opt/perforce/p4password/${P4PASSWD}"
+chmod 700 /opt/perforce/p4password
 
 exit
 

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -47,11 +47,13 @@ popd
 p4 -p $P4PORT group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
-# パスワードをファイル名として記録する（パスワード確認用）
-mkdir -p /opt/perforce/p4password
-touch "/opt/perforce/p4password/${P4PASSWD}"
-chmod 600 "/opt/perforce/p4password/${P4PASSWD}"
-chmod 700 /opt/perforce/p4password
+# パスワードをファイルに記録する（パスワード確認用）
+if [ -n "${P4PASSWD}" ]; then
+    mkdir -p /opt/perforce/p4password
+    chmod 700 /opt/perforce/p4password
+    printf '%s' "${P4PASSWD}" > /opt/perforce/p4password/password
+    chmod 600 /opt/perforce/p4password/password
+fi
 
 exit
 

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -47,6 +47,12 @@ popd
 p4 -p $P4PORT group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
+# パスワードをファイル名として記録する（パスワード確認用）
+mkdir -p /opt/perforce/p4password
+touch "/opt/perforce/p4password/${P4PASSWD}"
+chmod 600 "/opt/perforce/p4password/${P4PASSWD}"
+chmod 700 /opt/perforce/p4password
+
 exit
 
 fi


### PR DESCRIPTION
## 概要

ビルド時の `P4PASSWD` を、毎回自動生成されたランダムパスワードに切り替える対応です。
パスワードは `radicalgrimoire/utils` の再利用ワークフロー `generate-password.yml` で生成します。

## 変更内容

### `.github/workflows/test.yml`
- `generate-password` ジョブを追加
- `test` ジョブが `generate-password` に依存するよう変更
- `P4PASSWD` を `secrets.P4PASSWD` の固定値から生成済みパスワードに変更

### `.github/workflows/build-test.yml`
- `generate-password` ジョブを追加
- `build-test` ジョブが `generate-password` に依存するよう変更
- ビルドステップおよび統合テストステップの `P4PASSWD` を生成済みパスワードに変更

### `build/files/init.sh`
- サーバー初期設定の末尾に `/opt/perforce/p4password/<パスワード>` ファイルを作成する処理を追加
- ファイル名がパスワードそのものになるため、コンテナ内で `ls /opt/perforce/p4password/` を実行することでパスワードを確認可能

## 備考

`build-develop.yml` は `test.yml` を再利用ワークフローとして呼び出しているため、この変更は自動的に適用されます。個別の変更は不要です。