### PR TITLE
fix: improve password generation reliability with retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ services:
 
 ### 確認方法
 
-コンテナ内で以下を実行することでパスワードを確認できます。
+コンテナ内で `P4ROOT` を展開してパスワードを確認するには、以下を実行してください。
 
 ```bash
-docker exec <コンテナ名> cat "$(dirname "$P4ROOT")/p4password/super.password"
+docker exec <コンテナ名> sh -lc 'cat "$(dirname "$P4ROOT")/p4password/super.password"'
 ```
 
 `P4ROOT` が不明な場合は `make shell` でコンテナに入ってから確認してください。
@@ -169,7 +169,7 @@ docker run --rm -v servers:/opt/perforce/servers busybox \
   rm -f /opt/perforce/servers/<P4NAME>/root/.rotate_super_password_on_first_boot
 ```
 
-`P4ROOT` を変更している場合は、上記パスを `${P4ROOT}/.rotate_super_password_on_first_boot` に読み替えてください。
+`P4ROOT` を変更している場合は、上記パスをコンテナ内の環境変数 `P4ROOT` の値（例: `<P4ROOT>/.rotate_super_password_on_first_boot`）に読み替えてください。
 
 ### 既存環境への影響
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ services:
 デフォルト構成（`P4ROOT=/opt/perforce/servers/<P4NAME>/root`）では:
 
 ```text
-/opt/perforce/servers/p4password/super.password
+/opt/perforce/servers/<P4NAME>/p4password/super.password
 ```
 
 `P4ROOT` の値が異なる場合はパスが変わります。
@@ -161,12 +161,15 @@ docker exec <コンテナ名> cat "$(dirname "$P4ROOT")/p4password/super.passwor
 
 ### 無効化方法
 
-自動ローテーションを行いたくない場合は、初期化完了後にマーカーファイルを削除してからコンテナを起動してください。
+自動ローテーションを行いたくない場合は、初回起動前にボリューム側でマーカーファイルを削除してください。
 
 ```bash
-# 実行中コンテナで P4ROOT 配下のマーカーを削除する例
-docker exec <コンテナ名> sh -c 'rm -f "${P4ROOT}/.rotate_super_password_on_first_boot"'
+# 初回起動前にボリューム側でマーカーを削除する例
+docker run --rm -v servers:/opt/perforce/servers busybox \
+  rm -f /opt/perforce/servers/<P4NAME>/root/.rotate_super_password_on_first_boot
 ```
+
+`P4ROOT` を変更している場合は、上記パスを `${P4ROOT}/.rotate_super_password_on_first_boot` に読み替えてください。
 
 ### 既存環境への影響
 

--- a/README.md
+++ b/README.md
@@ -141,30 +141,31 @@ services:
 <P4ROOT の親ディレクトリ>/p4password/super.password
 ```
 
-`docker-compose.yml` のデフォルト構成では:
+デフォルト構成（`P4ROOT=/opt/perforce/servers/<P4NAME>/root`）では:
 
 ```text
 /opt/perforce/servers/p4password/super.password
 ```
+
+`P4ROOT` の値が異なる場合はパスが変わります。
 
 ### 確認方法
 
 コンテナ内で以下を実行することでパスワードを確認できます。
 
 ```bash
-docker exec <コンテナ名> cat /opt/perforce/servers/p4password/super.password
+docker exec <コンテナ名> cat "$(dirname "$P4ROOT")/p4password/super.password"
 ```
 
-または `make shell` でコンテナに入ってから確認してください。
+`P4ROOT` が不明な場合は `make shell` でコンテナに入ってから確認してください。
 
 ### 無効化方法
 
 自動ローテーションを行いたくない場合は、初期化完了後にマーカーファイルを削除してからコンテナを起動してください。
 
 ```bash
-# ボリューム上のマーカーを削除する例
-docker run --rm -v servers:/opt/perforce/servers busybox \
-  rm -f /opt/perforce/servers/<P4NAME>/root/.rotate_super_password_on_first_boot
+# 実行中コンテナで P4ROOT 配下のマーカーを削除する例
+docker exec <コンテナ名> sh -c 'rm -f "${P4ROOT}/.rotate_super_password_on_first_boot"'
 ```
 
 ### 既存環境への影響

--- a/README.md
+++ b/README.md
@@ -122,6 +122,56 @@ services:
 
 コンテナを再作成してもボリュームを削除しない限りデータは保持されます。
 
+## 初回起動時の super パスワードローテーション
+
+新規ボリュームで初めてコンテナを起動した際、`super` ユーザーのパスワードが自動的にローテーションされます。
+
+### 実施条件
+
+以下の条件を両方満たす場合にのみ実行されます。
+
+- 新規ボリューム（既存ボリュームでは実行しない）
+- 初回起動であること（ローテーション成功後はマーカーを削除し、2 回目以降は実行しない）
+
+### 保存先
+
+ローテーション後の `super` パスワードは以下のファイルに保存されます。
+
+```text
+<P4ROOT の親ディレクトリ>/p4password/super.password
+```
+
+`docker-compose.yml` のデフォルト構成では:
+
+```text
+/opt/perforce/servers/p4password/super.password
+```
+
+### 確認方法
+
+コンテナ内で以下を実行することでパスワードを確認できます。
+
+```bash
+docker exec <コンテナ名> cat /opt/perforce/servers/p4password/super.password
+```
+
+または `make shell` でコンテナに入ってから確認してください。
+
+### 無効化方法
+
+自動ローテーションを行いたくない場合は、初期化完了後にマーカーファイルを削除してからコンテナを起動してください。
+
+```bash
+# ボリューム上のマーカーを削除する例
+docker run --rm -v servers:/opt/perforce/servers busybox \
+  rm -f /opt/perforce/servers/<P4NAME>/root/.rotate_super_password_on_first_boot
+```
+
+### 既存環境への影響
+
+既存ボリュームにはマーカーファイルが存在しないため、自動ローテーションは実行されません。  
+既存の `P4PASSWD` 設定値は引き続き有効です。
+
 ## 接続方法
 
 P4V / CLI からの接続例:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,6 +4,7 @@ LABEL org.opencontainers.image.maintainer="ueno.s <ueno.s@gamestudio.co.jp>"
 # Add external files
 COPY files/run.sh /usr/local/bin/run.sh
 COPY files/init.sh /usr/local/bin/init.sh
+COPY files/generate-password.sh /usr/local/bin/generate-password.sh
 COPY files/p4.* /etc/logrotate.d/
 COPY files/CheckCaseTrigger*.py /usr/local/bin/
 COPY files/P4Triggers.py /usr/local/bin/P4Triggers.py
@@ -35,6 +36,7 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
     && apt-get update && apt-get install -y helix-p4d python3 perforce-p4python3 \
     && chmod +x /usr/local/bin/init.sh \
     && chmod +x /usr/local/bin/run.sh \
+    && chmod +x /usr/local/bin/generate-password.sh \
     && chmod 644 /etc/logrotate.d/p4.* \
     && git clone https://github.com/perforce/helix-authentication-extension.git /opt/helix-authentication-extension \
     && apt-get remove -y git \

--- a/build/files/generate-password.sh
+++ b/build/files/generate-password.sh
@@ -2,17 +2,36 @@
 set -euo pipefail
 
 LENGTH="${1:-16}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-20}"
 
 if ! [[ "$LENGTH" =~ ^[0-9]+$ ]] || [ "$LENGTH" -le 0 ]; then
   echo "Error: length must be a positive integer" >&2
   exit 1
 fi
 
-# 長さ不足に備えて大きめに生成し、許可文字のみを抽出する。
-PASSWORD="$(openssl rand -base64 "$(( LENGTH * 2 ))" | tr -dc 'a-zA-Z0-9!@#%^&*()_+=-' | head -c "$LENGTH")"
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$MAX_ATTEMPTS" -le 0 ]; then
+  echo "Error: MAX_ATTEMPTS must be a positive integer" >&2
+  exit 1
+fi
+
+ALLOWED_CHARS='a-zA-Z0-9!@#%^&*()_+=-'
+PASSWORD=""
+ATTEMPT=1
+
+while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+  # head を使わずに一度変数へ受けてから切り出し、pipefail と SIGPIPE の偶発失敗を避ける。
+  CANDIDATE="$(openssl rand -base64 "$(( LENGTH * 4 ))" | tr -dc "$ALLOWED_CHARS")"
+
+  if [ "${#CANDIDATE}" -ge "$LENGTH" ]; then
+    PASSWORD="${CANDIDATE:0:LENGTH}"
+    break
+  fi
+
+  ATTEMPT=$((ATTEMPT + 1))
+done
 
 if [ "${#PASSWORD}" -ne "$LENGTH" ]; then
-  echo "Error: failed to generate password with requested length" >&2
+  echo "Error: failed to generate password with requested length after ${MAX_ATTEMPTS} attempts" >&2
   exit 1
 fi
 

--- a/build/files/generate-password.sh
+++ b/build/files/generate-password.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LENGTH="${1:-16}"
+
+if ! [[ "$LENGTH" =~ ^[0-9]+$ ]] || [ "$LENGTH" -le 0 ]; then
+  echo "Error: length must be a positive integer" >&2
+  exit 1
+fi
+
+# 長さ不足に備えて大きめに生成し、許可文字のみを抽出する。
+PASSWORD="$(openssl rand -base64 "$(( LENGTH * 2 ))" | tr -dc 'a-zA-Z0-9!@#%^&*()_+=-' | head -c "$LENGTH")"
+
+if [ "${#PASSWORD}" -ne "$LENGTH" ]; then
+  echo "Error: failed to generate password with requested length" >&2
+  exit 1
+fi
+
+printf '%s\n' "$PASSWORD"

--- a/build/files/generate-password.sh
+++ b/build/files/generate-password.sh
@@ -19,8 +19,9 @@ PASSWORD=""
 ATTEMPT=1
 
 while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
-  # head を使わずに一度変数へ受けてから切り出し、pipefail と SIGPIPE の偶発失敗を避ける。
-  CANDIDATE="$(openssl rand -base64 "$(( LENGTH * 4 ))" | tr -dc "$ALLOWED_CHARS")"
+  # dd で固定バイト数だけ読み出してから tr でフィルタすることで
+  # 無限ストリームへの head 適用による SIGPIPE を回避する。
+  CANDIDATE="$(dd if=/dev/urandom bs=$(( LENGTH * 8 )) count=1 2>/dev/null | LC_ALL=C tr -dc "$ALLOWED_CHARS")"
 
   if [ "${#CANDIDATE}" -ge "$LENGTH" ]; then
     PASSWORD="${CANDIDATE:0:LENGTH}"

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -2,49 +2,51 @@
 
 if ! p4dctl list 2>/dev/null | grep -q $P4NAME; then
 
+run_p4_as_perforce() {
+	sudo -H -E -u perforce "$@"
+}
+
 /opt/perforce/sbin/configure-helix-p4d.sh $P4NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P $P4PASSWD --case $CASE_INSENSITIVE --unicode
 echo bash /opt/perforce/sbin/configure-helix-p4d.sh $P4NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P $P4PASSWD --case $CASE_INSENSITIVE --unicode
-p4 trust -y -f
+run_p4_as_perforce p4 trust -y -f
 
-p4 configure set server.extensions.allow.unsigned=1
-p4 configure set net.keepalive.idle=10
-p4 configure set net.keepalive.interval=30
-p4 configure set net.keepalive.count=3
+p4config_file="${P4HOME}/.p4config"
 
-cat > ~perforce/.p4config <<EOF
+cat > ${p4config_file} <<EOF
 P4USER=$P4USER
 P4PORT=$P4PORT
 P4PASSWD=$P4PASSWD
 EOF
 
-chmod 0600 ~perforce/.p4config
-chown perforce:perforce ~perforce/.p4config
+chmod 0600 ${p4config_file}
+chown perforce:perforce ${p4config_file}
 
-p4 login <<EOF
+run_p4_as_perforce p4 login <<EOF
 $P4PASSWD
 EOF
 
-su - perforce
+run_p4_as_perforce p4 configure set server.extensions.allow.unsigned=1
+run_p4_as_perforce p4 configure set net.keepalive.idle=10
+run_p4_as_perforce p4 configure set net.keepalive.interval=30
+run_p4_as_perforce p4 configure set net.keepalive.count=3
 
-yes ${P4PASSWD} | p4 -p ${P4PORT} -u super login
+TRIGGERS_FILE="$(mktemp)"
+run_p4_as_perforce p4 triggers -o > "${TRIGGERS_FILE}"
+echo '   CheckCaseTrigger change-submit //... "python3 /usr/local/bin/CheckCaseTrigger3.py %changelist% port=ssl:1666 user=super"' >> "${TRIGGERS_FILE}"
+run_p4_as_perforce p4 triggers -i < "${TRIGGERS_FILE}"
+rm -f "${TRIGGERS_FILE}"
 
-pushd /usr/local/bin/
-p4 triggers -o > triggers.txt
-echo '   CheckCaseTrigger change-submit //... "python3 /usr/local/bin/CheckCaseTrigger3.py %changelist% port=ssl:1666 user=super"' >> triggers.txt
-p4 triggers -i < triggers.txt
-popd
+if [ -f /opt/perforce/.p4trust ]; then
+	chown perforce:perforce /opt/perforce/.p4trust || true
+	chmod 600 /opt/perforce/.p4trust || true
+fi
 
-cp /root/.p4trust /opt/perforce/.p4trust
-cp /root/.p4tickets /opt/perforce/.p4tickets
+if [ -f /opt/perforce/.p4tickets ]; then
+	chown perforce:perforce /opt/perforce/.p4tickets || true
+	chmod 600 /opt/perforce/.p4tickets || true
+fi
 
-chown perforce:perforce /opt/perforce/.p4trust
-chown perforce:perforce /opt/perforce/.p4tickets
-
-pushd /opt/perforce
-p4 trust -y -f
-popd
-
-p4 -p $P4PORT group -i < /opt/perforce/admin.txt
+run_p4_as_perforce p4 -p $P4PORT group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
 # 新規環境でのみ初回起動時のパスワードローテーションを実行するためのマーカー

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if ! p4dctl list 2>/dev/null | grep -Fqx -- "$P4NAME"; then
 
@@ -6,8 +7,8 @@ run_p4_as_perforce() {
 	sudo -H -E -u perforce "$@"
 }
 
-/opt/perforce/sbin/configure-helix-p4d.sh $P4NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P $P4PASSWD --case $CASE_INSENSITIVE --unicode
-echo bash /opt/perforce/sbin/configure-helix-p4d.sh $P4NAME -n -p $P4PORT -r $P4ROOT -u $P4USER -P $P4PASSWD --case $CASE_INSENSITIVE --unicode
+/opt/perforce/sbin/configure-helix-p4d.sh "${P4NAME}" -n -p "${P4PORT}" -r "${P4ROOT}" -u "${P4USER}" -P "${P4PASSWD}" --case "${CASE_INSENSITIVE}" --unicode
+echo bash /opt/perforce/sbin/configure-helix-p4d.sh "${P4NAME}" -n -p "${P4PORT}" -r "${P4ROOT}" -u "${P4USER}" -P "${P4PASSWD}" --case "${CASE_INSENSITIVE}" --unicode
 run_p4_as_perforce p4 trust -y -f
 
 p4config_file="${P4HOME}/.p4config"
@@ -46,7 +47,7 @@ if [ -f /opt/perforce/.p4tickets ]; then
 	chmod 600 /opt/perforce/.p4tickets || true
 fi
 
-run_p4_as_perforce p4 -p $P4PORT group -i < /opt/perforce/admin.txt
+run_p4_as_perforce p4 -p "${P4PORT}" group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
 # 新規環境でのみ初回起動時のパスワードローテーションを実行するためのマーカー

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -47,6 +47,10 @@ popd
 p4 -p $P4PORT group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
+# 新規環境でのみ初回起動時のパスワードローテーションを実行するためのマーカー
+touch "${P4ROOT}/.rotate_super_password_on_first_boot"
+chmod 600 "${P4ROOT}/.rotate_super_password_on_first_boot"
+
 exit
 
 fi

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! p4dctl list 2>/dev/null | grep -q $P4NAME; then
+if ! p4dctl list 2>/dev/null | grep -Fqx -- "$P4NAME"; then
 
 run_p4_as_perforce() {
 	sudo -H -E -u perforce "$@"

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -12,14 +12,14 @@ run_p4_as_perforce p4 trust -y -f
 
 p4config_file="${P4HOME}/.p4config"
 
-cat > ${p4config_file} <<EOF
+cat > "${p4config_file}" <<EOF
 P4USER=$P4USER
 P4PORT=$P4PORT
 P4PASSWD=$P4PASSWD
 EOF
 
-chmod 0600 ${p4config_file}
-chown perforce:perforce ${p4config_file}
+chmod 0600 "${p4config_file}"
+chown perforce:perforce "${p4config_file}"
 
 run_p4_as_perforce p4 login <<EOF
 $P4PASSWD

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -8,7 +8,7 @@ run_p4_as_perforce() {
 }
 
 /opt/perforce/sbin/configure-helix-p4d.sh "${P4NAME}" -n -p "${P4PORT}" -r "${P4ROOT}" -u "${P4USER}" -P "${P4PASSWD}" --case "${CASE_INSENSITIVE}" --unicode
-echo bash /opt/perforce/sbin/configure-helix-p4d.sh "${P4NAME}" -n -p "${P4PORT}" -r "${P4ROOT}" -u "${P4USER}" -P "${P4PASSWD}" --case "${CASE_INSENSITIVE}" --unicode
+echo bash /opt/perforce/sbin/configure-helix-p4d.sh "${P4NAME}" -n -p "${P4PORT}" -r "${P4ROOT}" -u "${P4USER}" -P "****" --case "${CASE_INSENSITIVE}" --unicode
 run_p4_as_perforce p4 trust -y -f
 
 p4config_file="${P4HOME}/.p4config"

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -1,11 +1,84 @@
 #!/bin/bash
 set -e
 
+PASSWORD_DIR="/opt/perforce/servers/${P4NAME}/p4password"
+PASSWORD_FILE="${PASSWORD_DIR}/super.password"
+ROTATE_MARKER="${P4ROOT}/.rotate_super_password_on_first_boot"
+LOCK_DIR="${PASSWORD_DIR}/.lock"
+
+mkdir -p "${PASSWORD_DIR}"
+chmod 700 "${PASSWORD_DIR}"
+
 p4dctl start -t p4d $P4NAME
 sudo service cron start
 p4 trust -y -f
-yes $P4PASSWD | p4 login
-sudo -E -u perforce yes $P4PASSWD | p4 login
+
+login_with_password() {
+	local password="$1"
+	[ -n "$password" ] || return 1
+
+	if ! printf '%s\n' "$password" | p4 login > /dev/null 2>&1; then
+		return 1
+	fi
+
+	printf '%s\n' "$password" | sudo -E -u perforce p4 login > /dev/null 2>&1 || true
+	return 0
+}
+
+CURRENT_PASSWORD=""
+if [ -f "${PASSWORD_FILE}" ]; then
+	STORED_PASSWORD="$(head -n 1 "${PASSWORD_FILE}")"
+	if login_with_password "${STORED_PASSWORD}"; then
+		CURRENT_PASSWORD="${STORED_PASSWORD}"
+	else
+		echo "保存済みパスワードでのログインに失敗しました。P4PASSWDで再試行します。"
+		if login_with_password "${P4PASSWD}"; then
+			CURRENT_PASSWORD="${P4PASSWD}"
+		fi
+	fi
+else
+	if login_with_password "${P4PASSWD}"; then
+		CURRENT_PASSWORD="${P4PASSWD}"
+	fi
+fi
+
+if [ -z "${CURRENT_PASSWORD}" ] && [ -f "${ROTATE_MARKER}" ]; then
+	echo "初回ローテーション対象ですが、現在のsuperパスワードでログインできません。" >&2
+	exit 1
+fi
+
+if [ -z "${CURRENT_PASSWORD}" ] && [ ! -f "${ROTATE_MARKER}" ]; then
+	echo "既存環境のため、superログインに失敗しても起動は継続します。" >&2
+fi
+
+if [ -f "${ROTATE_MARKER}" ]; then
+	if mkdir "${LOCK_DIR}" 2>/dev/null; then
+		trap 'rmdir "${LOCK_DIR}" 2>/dev/null || true' EXIT
+
+		if [ -f "${ROTATE_MARKER}" ]; then
+			NEW_PASSWORD="$(/usr/local/bin/generate-password.sh 16)"
+
+			if p4 passwd <<EOF
+${CURRENT_PASSWORD}
+${NEW_PASSWORD}
+${NEW_PASSWORD}
+EOF
+			then
+				printf '%s\n' "${NEW_PASSWORD}" > "${PASSWORD_FILE}"
+				chmod 600 "${PASSWORD_FILE}"
+				chown perforce:perforce "${PASSWORD_FILE}" || true
+				rm -f "${ROTATE_MARKER}"
+
+				# 変更後パスワードで再ログイン
+				login_with_password "${NEW_PASSWORD}"
+			else
+				echo "superユーザーのパスワード変更に失敗しました。" >&2
+				exit 1
+			fi
+		fi
+	fi
+fi
+
 cat /root/.p4trust > /opt/perforce/.p4trust
 cat /root/.p4tickets > /opt/perforce/.p4tickets
 exec /usr/bin/tail --pid=$(cat /var/run/p4d.$P4NAME.pid) -F "$P4ROOT/logs/log"

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-PASSWORD_DIR="/opt/perforce/servers/${P4NAME}/p4password"
+P4ROOT_PARENT="$(dirname "$P4ROOT")"
+PASSWORD_DIR="${P4ROOT_PARENT}/p4password"
 PASSWORD_FILE="${PASSWORD_DIR}/super.password"
 ROTATE_MARKER="${P4ROOT}/.rotate_super_password_on_first_boot"
 LOCK_DIR="${PASSWORD_DIR}/.lock"

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -4,7 +4,7 @@ set -e
 PASSWORD_DIR="/opt/perforce/servers/${P4NAME}/p4password"
 PASSWORD_FILE="${PASSWORD_DIR}/super.password"
 ROTATE_MARKER="${P4ROOT}/.rotate_super_password_on_first_boot"
-LOCK_DIR="${PASSWORD_DIR}/.lock"
+LOCK_FILE="${PASSWORD_DIR}/.rotate_super_password.lock"
 
 mkdir -p "${PASSWORD_DIR}"
 chmod 700 "${PASSWORD_DIR}"
@@ -16,6 +16,9 @@ p4 trust -y -f
 login_with_password() {
 	local password="$1"
 	[ -n "$password" ] || return 1
+
+	p4 logout > /dev/null 2>&1 || true
+	sudo -E -u perforce p4 logout > /dev/null 2>&1 || true
 
 	if ! printf '%s\n' "$password" | p4 login > /dev/null 2>&1; then
 		return 1
@@ -52,9 +55,8 @@ if [ -z "${CURRENT_PASSWORD}" ] && [ ! -f "${ROTATE_MARKER}" ]; then
 fi
 
 if [ -f "${ROTATE_MARKER}" ]; then
-	if mkdir "${LOCK_DIR}" 2>/dev/null; then
-		trap 'rmdir "${LOCK_DIR}" 2>/dev/null || true' EXIT
-
+	exec 9>"${LOCK_FILE}"
+	if flock -n 9; then
 		if [ -f "${ROTATE_MARKER}" ]; then
 			NEW_PASSWORD="$(/usr/local/bin/generate-password.sh 16)"
 
@@ -64,10 +66,11 @@ ${NEW_PASSWORD}
 ${NEW_PASSWORD}
 EOF
 			then
-				printf '%s\n' "${NEW_PASSWORD}" > "${PASSWORD_FILE}"
+				( umask 077; printf '%s\n' "${NEW_PASSWORD}" > "${PASSWORD_FILE}" )
 				chmod 600 "${PASSWORD_FILE}"
-				chown perforce:perforce "${PASSWORD_FILE}" || true
 				rm -f "${ROTATE_MARKER}"
+				echo "初回ローテーションを実施しました。" >&2
+				echo "新しいsuperパスワードは次のファイルに保存されています: ${PASSWORD_FILE}" >&2
 
 				# 変更後パスワードで再ログイン
 				login_with_password "${NEW_PASSWORD}"
@@ -76,9 +79,13 @@ EOF
 				exit 1
 			fi
 		fi
+	else
+		echo "superユーザーのパスワードローテーションは他のプロセスが実行中のため待機せず継続します。" >&2
 	fi
 fi
 
-cat /root/.p4trust > /opt/perforce/.p4trust
-cat /root/.p4tickets > /opt/perforce/.p4tickets
+cp /root/.p4trust /opt/perforce/.p4trust
+cp /root/.p4tickets /opt/perforce/.p4tickets
+chown perforce:perforce /opt/perforce/.p4trust /opt/perforce/.p4tickets || true
+chmod 600 /opt/perforce/.p4trust /opt/perforce/.p4tickets || true
 exec /usr/bin/tail --pid=$(cat /var/run/p4d.$P4NAME.pid) -F "$P4ROOT/logs/log"

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -10,22 +10,24 @@ LOCK_FILE="${PASSWORD_DIR}/.rotate_super_password.lock"
 mkdir -p "${PASSWORD_DIR}"
 chmod 700 "${PASSWORD_DIR}"
 
+run_p4_as_perforce() {
+	sudo -H -E -u perforce "$@"
+}
+
 p4dctl start -t p4d $P4NAME
 sudo service cron start
-p4 trust -y -f
+run_p4_as_perforce p4 trust -y -f
 
 login_with_password() {
 	local password="$1"
 	[ -n "$password" ] || return 1
 
-	p4 logout > /dev/null 2>&1 || true
-	sudo -E -u perforce p4 logout > /dev/null 2>&1 || true
+	run_p4_as_perforce p4 logout > /dev/null 2>&1 || true
 
-	if ! printf '%s\n' "$password" | p4 login > /dev/null 2>&1; then
+	if ! printf '%s\n' "$password" | run_p4_as_perforce p4 login > /dev/null 2>&1; then
 		return 1
 	fi
 
-	printf '%s\n' "$password" | sudo -E -u perforce p4 login > /dev/null 2>&1 || true
 	return 0
 }
 
@@ -61,7 +63,7 @@ if [ -f "${ROTATE_MARKER}" ]; then
 		if [ -f "${ROTATE_MARKER}" ]; then
 			NEW_PASSWORD="$(/usr/local/bin/generate-password.sh 16)"
 
-			if p4 passwd <<EOF
+			if run_p4_as_perforce p4 passwd <<EOF
 ${CURRENT_PASSWORD}
 ${NEW_PASSWORD}
 ${NEW_PASSWORD}
@@ -85,8 +87,14 @@ EOF
 	fi
 fi
 
-cp /root/.p4trust /opt/perforce/.p4trust
-cp /root/.p4tickets /opt/perforce/.p4tickets
-chown perforce:perforce /opt/perforce/.p4trust /opt/perforce/.p4tickets || true
-chmod 600 /opt/perforce/.p4trust /opt/perforce/.p4tickets || true
+if [ -f /opt/perforce/.p4trust ]; then
+	chown perforce:perforce /opt/perforce/.p4trust || true
+	chmod 600 /opt/perforce/.p4trust || true
+fi
+
+if [ -f /opt/perforce/.p4tickets ]; then
+	chown perforce:perforce /opt/perforce/.p4tickets || true
+	chmod 600 /opt/perforce/.p4tickets || true
+fi
+
 exec /usr/bin/tail --pid=$(cat /var/run/p4d.$P4NAME.pid) -F "$P4ROOT/logs/log"

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -76,7 +76,10 @@ EOF
 				echo "新しいsuperパスワードは次のファイルに保存されています: ${PASSWORD_FILE}" >&2
 
 				# 変更後パスワードで再ログイン
-				login_with_password "${NEW_PASSWORD}"
+				if ! login_with_password "${NEW_PASSWORD}"; then
+					echo "ローテーション後のsuperユーザーログインに失敗しました。" >&2
+					exit 1
+				fi
 			else
 				echo "superユーザーのパスワード変更に失敗しました。" >&2
 				exit 1

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -14,7 +14,7 @@ run_p4_as_perforce() {
 	sudo -H -E -u perforce "$@"
 }
 
-p4dctl start -t p4d $P4NAME
+p4dctl start -t p4d "${P4NAME}"
 sudo service cron start
 run_p4_as_perforce p4 trust -y -f
 
@@ -100,4 +100,4 @@ if [ -f /opt/perforce/.p4tickets ]; then
 	chmod 600 /opt/perforce/.p4tickets || true
 fi
 
-exec /usr/bin/tail --pid=$(cat /var/run/p4d.$P4NAME.pid) -F "$P4ROOT/logs/log"
+exec /usr/bin/tail --pid="$(cat "/var/run/p4d.${P4NAME}.pid")" -F "${P4ROOT}/logs/log"


### PR DESCRIPTION
## 概要

Helix Core コンテナの初期化・起動処理を見直し、以下を改善しました。

- パスワード生成処理の信頼性向上（SIGPIPE 回避・リトライ）
- 新規環境の初回起動時における super パスワード自動ローテーション
- Perforce 認証処理の実行主体を perforce ユーザーに統一
- クォート不足や部分一致判定など、運用時に誤動作し得る箇所の修正
- README のローテーション仕様説明を実装と整合

## 主な変更

### 1. パスワード生成の安定化（build/files/generate-password.sh）

- 固定長読み出し後に文字集合フィルタする方式に整理
- SIGPIPE 由来の偶発失敗を回避
- リトライ処理を維持し、要求長が得られない場合は明示失敗

### 2. 初回起動時の super パスワード自動ローテーション（build/files/init.sh / build/files/run.sh）

- 新規環境でのみ初回起動時にローテーションを実施
- 成功後はマーカー削除により再実行防止
- 保存先は `<P4ROOT の親ディレクトリ>/p4password/super.password`

### 3. 認証処理の perforce ユーザー統一（build/files/init.sh / build/files/run.sh）

- `p4 trust / login / logout / passwd` を perforce ユーザー主体に統一
- root の `.p4tickets` / `.p4trust` 依存を削減
- 起動継続経路での不要な失敗を回避

### 4. レビュー指摘フォローアップ

#### build/files/init.sh

- `set -euo pipefail` を追加
- 初期化判定を `grep -Fqx -- "$P4NAME"` に変更（固定文字列・完全一致）
- `configure-helix-p4d.sh` 呼び出し引数をクォート
- `p4 -p "${P4PORT}"` に修正
- デバッグ出力の `-P` 引数は `****` にマスク（パスワード露出防止）

#### build/files/run.sh

- `p4dctl start -t p4d "${P4NAME}"` に修正
- ローテーション後の再ログイン失敗を明示的に `exit 1`
- `tail --pid` とログファイル引数の変数展開をクォート

### 5. README 更新（README.md）

- ローテーション実施条件・保存先・既存環境影響を明記
- 保存先/確認方法を `P4ROOT` 依存であることが分かる表記へ修正
- 確認コマンドをコンテナ内で `P4ROOT` 展開する形へ修正
- 無効化方法を「初回起動前にボリューム側でマーカー削除」に修正
- `P4ROOT` 表記をホスト側環境変数と誤解しない文言へ修正

## 既存環境への影響

既存ボリュームには初回起動用マーカーが存在しないため、自動ローテーションは実行されません。既存環境の運用への影響はありません。

## 変更ファイル

- README.md
- build/files/generate-password.sh
- build/files/init.sh
- build/files/run.sh