### PR TITLE
fix: set runtime P4PASSWD for root context

### DIFF
--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -72,6 +72,7 @@ EOF
 				( umask 077; printf '%s\n' "${NEW_PASSWORD}" > "${PASSWORD_FILE}" )
 				chmod 600 "${PASSWORD_FILE}"
 				run_p4_as_perforce p4 set "P4PASSWD=${NEW_PASSWORD}"
+				p4 set "P4PASSWD=${NEW_PASSWORD}"
 				cat > /opt/perforce/servers/.p4config <<EOF
 P4USER=${P4USER}
 P4PORT=${P4PORT}


### PR DESCRIPTION
## 概要
ランタイムのパスワードローテーション時に root コンテキストでも P4PASSWD を更新するように修正しました。

## 変更内容
- run.sh でローテーション後に root 用の p4 set を実行

## 確認観点
- 初回ローテーション後に root で p4 set した値が更新されること