### PR TITLE
Translate source comments and messages to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,109 @@
 # Docker Helix Core
 
-Perforce Helix Core (P4D) サーバーを Docker コンテナで実行するためのリポジトリです。  
-現在の標準起動構成は、`p4d/Dockerfile` から既存イメージを参照して `docker-compose.yml` で起動する方式です。
+This repository runs a Perforce Helix Core (P4D) server in a Docker container.  
+The current standard startup flow uses an existing image referenced by p4d/Dockerfile and starts it through docker-compose.yml.
 
-## 概要
+## Overview
 
-- 開発・検証向けの Helix Core コンテナ環境
-- SSL 接続 (`1666`) 前提の構成
-- 起動時ヘルスチェックあり
-- ケース一貫性チェック用トリガー（`CheckCaseTrigger3.py`）を含むイメージを利用
-- データは Docker ボリューム `servers` に永続化
+- Helix Core container environment for development and validation
+- SSL-based configuration on port 1666
+- Startup health check included
+- Uses an image that contains the case-consistency trigger, CheckCaseTrigger3.py
+- Data is persisted in the Docker volume named servers
 
-## 現在の構成
+## Current Layout
 
-主要ファイル:
+Main files:
 
-- `docker-compose.yml`: コンテナ起動設定（`helix-p4d`）
-- `Makefile`: 主要操作コマンド（起動/停止/ログ/シェル/ビルド）
-- `p4d/Dockerfile`: `ghcr.io/radicalgrimoire/docker-helixcore/helix-p4d:latest` ベースの実行用イメージ
-- `build/Dockerfile`: ベースイメージを独自に再構築するための定義
-- `build/files/init.sh`: 初期セットアップ（サーバー設定・トリガー設定）
-- `build/files/run.sh`: サーバー起動・ログ出力
+- docker-compose.yml: Container startup settings for helix-p4d
+- Makefile: Main operational commands for start, stop, logs, shell, and build
+- p4d/Dockerfile: Runtime image based on ghcr.io/radicalgrimoire/docker-helixcore/helix-p4d:latest
+- build/Dockerfile: Definition used to rebuild the base image yourself
+- build/files/init.sh: Initial setup for server and trigger configuration
+- build/files/run.sh: Server startup and log output
 
-ネットワーク/ポート設定（`docker-compose.yml`）:
+Network and port settings in docker-compose.yml:
 
-- カスタムネットワーク: `app_net` (`172.16.238.0/24`)
-- コンテナ IP: `172.16.238.10`
-- 公開ポート: `1666:1666`
+- Custom network: app_net (172.16.238.0/24)
+- Container IP: 172.16.238.10
+- Published port: 1666:1666
 
-## 前提条件
+## Prerequisites
 
 - Docker
 - Docker Compose
-- Make（`Makefile` 利用時）
-- Windows で `make shell` を使う場合は `winpty` が必要
+- Make if you want to use the Makefile
+- winpty on Windows if you want to use make shell
 
-## クイックスタート
+## Quick Start
 
-### 1. 起動
+### 1. Start
 
 ```bash
 make start
 ```
 
-または:
+Or:
 
 ```bash
 docker-compose -f docker-compose.yml -p helixcore up -d
 ```
 
-### 2. ログ確認
+### 2. View Logs
 
 ```bash
 make logs
 ```
 
-### 3. シェル接続
+### 3. Open a Shell
 
 ```bash
 make shell
 ```
 
-### 4. 停止
+### 4. Stop
 
 ```bash
 make stop
 ```
 
-### 5. コンテナ削除
+### 5. Remove the Container
 
 ```bash
 make remove
 ```
 
-## Makefile コマンド
+## Makefile Commands
 
-- `make start`: 起動
-- `make stop`: 停止
-- `make remove`: `docker-compose down`
-- `make logs`: ログ追従
-- `make shell`: コンテナ内シェル
-- `make build`: イメージビルド
-- `make rebuild`: キャッシュ無しで再ビルド
+- make start: Start the container
+- make stop: Stop the container
+- make remove: Run docker-compose down
+- make logs: Follow container logs
+- make shell: Open a shell inside the container
+- make build: Build the image
+- make rebuild: Rebuild without cache
 
-## 環境変数
+## Environment Variables
 
-このプロジェクトで利用する主な環境変数:
+Main environment variables used by this project:
 
-| 変数名 | 説明 | 代表値 |
+| Variable | Description | Example value |
 | --- | --- | --- |
-| `P4NAME` | Perforce サーバー名 | 任意 |
-| `P4PORT` | Perforce サーバーポート | `ssl:1666` |
-| `P4USER` | 管理者ユーザー | `super` |
-| `P4PASSWD` | 管理者パスワード | 任意 |
-| `P4HOME` | Perforce ホーム | `/opt/perforce` |
-| `P4ROOT` | Perforce ルート | 例: `/opt/perforce/servers/<server>/root` |
-| `CASE_INSENSITIVE` | 大文字小文字設定 | `0` |
+| P4NAME | Perforce server name | Any value |
+| P4PORT | Perforce server port | ssl:1666 |
+| P4USER | Administrator user | super |
+| P4PASSWD | Administrator password | Any value |
+| P4HOME | Perforce home directory | /opt/perforce |
+| P4ROOT | Perforce root directory | Example: /opt/perforce/servers/your-server/root |
+| CASE_INSENSITIVE | Case-sensitivity setting | 0 |
 
-注記:
+Notes:
 
-- 現在の `docker-compose.yml` では環境変数を明示指定していません。
-- 既定動作は参照元イメージ側の設定に依存します。
-- 値を固定したい場合は `docker-compose.yml` の `services.helixcore.environment` に明示してください。
+- The current docker-compose.yml does not declare environment variables explicitly.
+- Default behavior depends on the referenced image configuration.
+- If you want to pin values, add them under services.helixcore.environment in docker-compose.yml.
 
-例:
+Example:
 
 ```yaml
 services:
@@ -115,124 +115,124 @@ services:
       P4PASSWD: your-password
 ```
 
-## データ永続化
+## Data Persistence
 
-- ボリューム: `servers`
-- マウント先: `/opt/perforce/servers`
+- Volume: servers
+- Mount point: /opt/perforce/servers
 
-コンテナを再作成してもボリュームを削除しない限りデータは保持されます。
+Data is preserved across container recreation unless you delete the volume.
 
-## 初回起動時の super パスワードローテーション
+## First-Boot super Password Rotation
 
-新規ボリュームで初めてコンテナを起動した際、`super` ユーザーのパスワードが自動的にローテーションされます。
+When the container starts for the first time with a new volume, the password for the super user is rotated automatically.
 
-### 実施条件
+### Conditions
 
-以下の条件を両方満たす場合にのみ実行されます。
+This runs only when both conditions are met:
 
-- 新規ボリューム（既存ボリュームでは実行しない）
-- 初回起動であること（ローテーション成功後はマーカーを削除し、2 回目以降は実行しない）
+- The volume is new and not an existing one
+- This is the first startup; after a successful rotation, the marker file is removed so it does not run again
 
-### 保存先
+### Storage Location
 
-ローテーション後の `super` パスワードは以下のファイルに保存されます。
+After rotation, the super password is stored in the following file:
 
 ```text
-<P4ROOT の親ディレクトリ>/p4password/super.password
+<parent directory of P4ROOT>/p4password/super.password
 ```
 
-デフォルト構成（`P4ROOT=/opt/perforce/servers/<P4NAME>/root`）では:
+With the default layout where `P4ROOT=/opt/perforce/servers/<P4NAME>/root`:
 
 ```text
 /opt/perforce/servers/<P4NAME>/p4password/super.password
 ```
 
-`P4ROOT` の値が異なる場合はパスが変わります。
+If P4ROOT is changed, this path changes as well.
 
-### 確認方法
+### How to Check It
 
-コンテナ内で `P4ROOT` を展開してパスワードを確認するには、以下を実行してください。
+To expand P4ROOT inside the container and display the password file, run:
 
 ```bash
-docker exec <コンテナ名> sh -lc 'cat "$(dirname "$P4ROOT")/p4password/super.password"'
+docker exec <container-name> sh -lc 'cat "$(dirname "$P4ROOT")/p4password/super.password"'
 ```
 
-`P4ROOT` が不明な場合は `make shell` でコンテナに入ってから確認してください。
+If you do not know the value of P4ROOT, enter the container with make shell and inspect it there.
 
-### 無効化方法
+### How to Disable It
 
-自動ローテーションを行いたくない場合は、初回起動前にボリューム側でマーカーファイルを削除してください。
+If you do not want automatic rotation, delete the marker file on the volume before the first startup.
 
 ```bash
-# 初回起動前にボリューム側でマーカーを削除する例
+# Example: remove the marker on the volume before the first startup
 docker run --rm -v servers:/opt/perforce/servers busybox \
   rm -f /opt/perforce/servers/<P4NAME>/root/.rotate_super_password_on_first_boot
 ```
 
-`P4ROOT` を変更している場合は、上記パスをコンテナ内の環境変数 `P4ROOT` の値（例: `<P4ROOT>/.rotate_super_password_on_first_boot`）に読み替えてください。
+If you have changed P4ROOT, replace the path above with the actual value of P4ROOT inside the container, for example `P4ROOT/.rotate_super_password_on_first_boot`.
 
-### 既存環境への影響
+### Impact on Existing Environments
 
-既存ボリュームにはマーカーファイルが存在しないため、自動ローテーションは実行されません。  
-既存の `P4PASSWD` 設定値は引き続き有効です。
+Existing volumes do not contain the marker file, so automatic rotation does not run.  
+Existing P4PASSWD values remain valid.
 
-## 接続方法
+## Connecting
 
-P4V / CLI からの接続例:
+Example connection settings for P4V or the CLI:
 
-- サーバー: `ssl:localhost:1666`
-- ユーザー: `super`（または設定したユーザー）
-- パスワード: 設定値
+- Server: ssl:localhost:1666
+- User: super or the user you configured
+- Password: your configured value
 
-CLI 例:
+CLI example:
 
 ```bash
 p4 -p ssl:localhost:1666 -u super login
 ```
 
-## 独自ビルド（必要時）
+## Custom Builds
 
-通常運用では `p4d/Dockerfile` による既存イメージ利用で十分です。  
-独自イメージを作る場合は `build/` を使用します。
+For standard usage, the prebuilt-image flow through p4d/Dockerfile is usually sufficient.  
+Use build/ only when you need to create a custom image.
 
 ```bash
 make build
 make rebuild
 ```
 
-または:
+Or:
 
 ```bash
 bash build/docker-build.sh Dockerfile ./build
 ```
 
-## トラブルシューティング
+## Troubleshooting
 
-### 起動しない
+### Startup Fails
 
-- `1666` ポート使用状況を確認
-- `make logs` でエラー確認
-- `docker ps -a` でコンテナ状態を確認
+- Check whether port 1666 is already in use
+- Review errors with make logs
+- Check container state with docker ps -a
 
-### 接続できない
+### Cannot Connect
 
-- 接続先が `ssl:localhost:1666` になっているか確認
-- 初回接続時に証明書信頼が必要な場合あり
+- Verify that the target server is ssl:localhost:1666
+- Certificate trust may be required on the first connection
 
-### 状態確認
+### Check Status
 
 ```bash
 make shell
 p4dctl status
 ```
 
-## 参考リンク
+## References
 
-- [Perforce Helix Core ドキュメント](https://www.perforce.com/manuals/p4sag/)
-- [コンテナイメージ](https://github.com/radicalgrimoire/docker-helixcore/pkgs/container/docker-helixcore%2Fhelix-p4d)
+- [Perforce Helix Core documentation](https://www.perforce.com/manuals/p4sag/)
+- [Container image](https://github.com/radicalgrimoire/docker-helixcore/pkgs/container/docker-helixcore%2Fhelix-p4d)
 - [Helix Authentication Extension](https://github.com/perforce/helix-authentication-extension)
 
-## 注意事項
+## Notes
 
-この構成は開発・検証用途を想定しています。  
-本番利用時は、認証/権限管理、ネットワーク制限、バックアップ、監視、証明書運用を別途設計してください。
+This setup is intended for development and validation use.  
+For production use, design authentication and authorization, network restrictions, backup, monitoring, and certificate operations separately.

--- a/build/docker-build.sh
+++ b/build/docker-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# docker-build.sh: .envファイルから環境変数を読み込み、--build-argとしてdocker buildに渡す
-# 使い方: ./docker-build.sh [Dockerfile名] [ビルドパス]
+# docker-build.sh: Load environment variables from .env and pass them to docker build as --build-arg values.
+# Usage: ./docker-build.sh [Dockerfile name] [build path]
 set -e
 
 DOCKERFILE_NAME="${1:-Dockerfile}"
@@ -9,14 +9,14 @@ IMAGE_NAME="${IMAGE_NAME:-helix-p4d-test}"
 
 echo "Building Docker image with $DOCKERFILE_NAME..."
 
-# .envファイルと環境変数の読み込みで--build-arg生成
+# Build the --build-arg list from .env and environment variables.
 BUILD_ARGS=""
 
-# 通常の.envファイルを読み込み
+# Load the standard .env file.
 ENV_PATH="$BUILD_PATH/.env"
 if [ -f "$ENV_PATH" ]; then
     while IFS='=' read -r key value; do
-        # コメント・空行・export除外
+        # Skip comments, blank lines, and the export prefix.
         if [[ "$key" =~ ^# ]] || [[ -z "$key" ]]; then continue; fi
         key=$(echo "$key" | sed 's/^export //')
         value=$(echo "$value" | sed 's/^\s*//;s/\s*$//')
@@ -24,7 +24,7 @@ if [ -f "$ENV_PATH" ]; then
     done < "$ENV_PATH"
 fi
 
-# CIなどで渡された環境変数をbuild-argへ反映（値はログ出力しない）
+# Include environment variables provided by CI or other callers as build args without logging their values.
 for key in P4NAME P4PORT P4USER P4PASSWD P4HOME P4ROOT CASE_INSENSITIVE; do
     value="${!key}"
     if [ -n "$value" ]; then

--- a/build/files/generate-password.sh
+++ b/build/files/generate-password.sh
@@ -19,8 +19,8 @@ PASSWORD=""
 ATTEMPT=1
 
 while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
-  # dd で固定バイト数だけ読み出してから tr でフィルタすることで
-  # 無限ストリームへの head 適用による SIGPIPE を回避する。
+  # Read a fixed number of bytes with dd and then filter with tr
+  # to avoid SIGPIPE caused by applying head to an infinite stream.
   CANDIDATE="$(dd if=/dev/urandom bs=$(( LENGTH * 8 )) count=1 2>/dev/null | LC_ALL=C tr -dc "$ALLOWED_CHARS")"
 
   if [ "${#CANDIDATE}" -ge "$LENGTH" ]; then

--- a/build/files/init.sh
+++ b/build/files/init.sh
@@ -50,7 +50,7 @@ fi
 run_p4_as_perforce p4 -p "${P4PORT}" group -i < /opt/perforce/admin.txt
 rm -f /opt/perforce/admin.txt
 
-# 新規環境でのみ初回起動時のパスワードローテーションを実行するためのマーカー
+# Marker used to trigger first-boot password rotation only for new environments.
 touch "${P4ROOT}/.rotate_super_password_on_first_boot"
 chmod 600 "${P4ROOT}/.rotate_super_password_on_first_boot"
 

--- a/build/files/run.sh
+++ b/build/files/run.sh
@@ -51,7 +51,7 @@ if [ -f "${PASSWORD_FILE}" ]; then
 	if login_with_password "${STORED_PASSWORD}"; then
 		CURRENT_PASSWORD="${STORED_PASSWORD}"
 	else
-		echo "保存済みパスワードでのログインに失敗しました。P4PASSWDで再試行します。"
+		echo "Login with the stored password failed. Retrying with P4PASSWD."
 		if login_with_password "${P4PASSWD}"; then
 			CURRENT_PASSWORD="${P4PASSWD}"
 		fi
@@ -63,12 +63,12 @@ else
 fi
 
 if [ -z "${CURRENT_PASSWORD}" ] && [ -f "${ROTATE_MARKER}" ]; then
-	echo "初回ローテーション対象ですが、現在のsuperパスワードでログインできません。" >&2
+	echo "This instance is marked for first-boot rotation, but login with the current super password failed." >&2
 	exit 1
 fi
 
 if [ -z "${CURRENT_PASSWORD}" ] && [ ! -f "${ROTATE_MARKER}" ]; then
-	echo "既存環境のため、superログインに失敗しても起動は継続します。" >&2
+	echo "This appears to be an existing environment, so startup will continue even though super login failed." >&2
 fi
 
 if [ -n "${CURRENT_PASSWORD}" ]; then
@@ -92,21 +92,21 @@ EOF
 				CURRENT_PASSWORD="${NEW_PASSWORD}"
 				write_p4config "${CURRENT_PASSWORD}"
 				rm -f "${ROTATE_MARKER}"
-				echo "初回ローテーションを実施しました。" >&2
-				echo "新しいsuperパスワードは次のファイルに保存されています: ${PASSWORD_FILE}" >&2
+				echo "First-boot password rotation completed." >&2
+				echo "The new super password has been saved to: ${PASSWORD_FILE}" >&2
 
-				# 変更後パスワードで再ログイン
+				# Log in again with the updated password.
 				if ! login_with_password "${NEW_PASSWORD}"; then
-					echo "ローテーション後のsuperユーザーログインに失敗しました。" >&2
+					echo "Login for the super user failed after password rotation." >&2
 					exit 1
 				fi
 			else
-				echo "superユーザーのパスワード変更に失敗しました。" >&2
+				echo "Failed to change the super user password." >&2
 				exit 1
 			fi
 		fi
 	else
-		echo "superユーザーのパスワードローテーションは他のプロセスが実行中のため待機せず継続します。" >&2
+		echo "Another process is already rotating the super user password, so startup will continue without waiting." >&2
 	fi
 fi
 

--- a/p4d/download-certs.sh
+++ b/p4d/download-certs.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
 
-# Helix P4D SAML証明書ダウンロードスクリプト
+# Helix P4D SAML certificate download script.
 
 set -e
 
-# 使用方法を表示
+# Show usage information.
 show_usage() {
   cat << EOF
-使用方法: $0 [OPTIONS]
+Usage: $0 [OPTIONS]
 
 OPTIONS:
-  -r, --repo REPO        GitHubリポジトリ (形式: owner/repository)
-  -t, --token TOKEN      GitHubトークン
-  -d, --dir DIRECTORY    保存先ディレクトリ (デフォルト: ./certs)
-  -y, --yes              確認をスキップ
-  -h, --help             このヘルプを表示
+  -r, --repo REPO        GitHub repository (format: owner/repository)
+  -t, --token TOKEN      GitHub token
+  -d, --dir DIRECTORY    Download directory (default: ./certs)
+  -y, --yes              Skip confirmation
+  -h, --help             Show this help message
 
-環境変数:
-  GITHUB_REPO           リポジトリ名
-  GITHUB_TOKEN          GitHubトークン
-  CERT_DIR              保存先ディレクトリ
+Environment variables:
+  GITHUB_REPO           Repository name
+  GITHUB_TOKEN          GitHub token
+  CERT_DIR              Download directory
 
-例:
-  # 対話形式
+Examples:
+  # Interactive mode
   $0
 
-  # 引数で指定
+  # Specify values with arguments
   $0 -r owner/repo -t ghp_token -d ./certs
 
-  # 環境変数で指定
+  # Specify values with environment variables
   export GITHUB_REPO="owner/repo"
   export GITHUB_TOKEN="ghp_token"
   $0 -y
@@ -37,7 +37,7 @@ EOF
   exit 0
 }
 
-# 引数の解析
+# Parse arguments.
 REPO=""
 TOKEN=""
 DOWNLOAD_DIR=""
@@ -65,101 +65,101 @@ while [[ $# -gt 0 ]]; do
       show_usage
       ;;
     *)
-      echo "エラー: 不明なオプション: $1"
-      echo "ヘルプを表示: $0 --help"
+      echo "Error: unknown option: $1"
+      echo "Show help with: $0 --help"
       exit 1
       ;;
   esac
 done
 
 echo "==================================="
-echo "Helix P4D SAML証明書ダウンロード"
+echo "Helix P4D SAML Certificate Download"
 echo "==================================="
 echo ""
 
-# リポジトリの設定（優先順位: 引数 > 環境変数 > 対話入力）
+# Configure the repository with the following precedence: arguments, environment variables, then interactive input.
 if [ -z "${REPO}" ]; then
   if [ -n "${GITHUB_REPO}" ]; then
     REPO="${GITHUB_REPO}"
-    echo "リポジトリ: ${REPO} (環境変数から)"
+    echo "Repository: ${REPO} (from environment variable)"
   else
-    echo "GitHubリポジトリを入力してください"
-    echo "形式: owner/repository"
-    read -p "リポジトリ [radicalgrimoire/pfx-tools]: " input_repo
+    echo "Enter the GitHub repository."
+    echo "Format: owner/repository"
+    read -p "Repository [radicalgrimoire/pfx-tools]: " input_repo
     REPO="${input_repo:-radicalgrimoire/pfx-tools}"
   fi
 else
-  echo "リポジトリ: ${REPO} (引数から)"
+  echo "Repository: ${REPO} (from argument)"
 fi
 
-# ダウンロードディレクトリの設定
+# Configure the download directory.
 if [ -z "${DOWNLOAD_DIR}" ]; then
   if [ -n "${CERT_DIR}" ]; then
     DOWNLOAD_DIR="${CERT_DIR}"
-    echo "保存先: ${DOWNLOAD_DIR} (環境変数から)"
+    echo "Download directory: ${DOWNLOAD_DIR} (from environment variable)"
   else
-    read -p "保存先ディレクトリ [./certs]: " input_dir
+    read -p "Download directory [./certs]: " input_dir
     DOWNLOAD_DIR="${input_dir:-./certs}"
   fi
 else
-  echo "保存先: ${DOWNLOAD_DIR} (引数から)"
+  echo "Download directory: ${DOWNLOAD_DIR} (from argument)"
 fi
 
-# トークンの設定
+# Configure the token.
 if [ -z "${TOKEN}" ]; then
   if [ -n "${GITHUB_TOKEN}" ]; then
     TOKEN="${GITHUB_TOKEN}"
-    echo "認証: トークン設定済み ✓ (環境変数から)"
+    echo "Authentication: token configured (from environment variable)"
   else
     echo ""
-    echo "GitHubトークンを入力してください（プライベートリポジトリの場合必須）"
-    echo "トークンの作成: https://github.com/settings/tokens"
-    echo "必要な権限: repo"
+    echo "Enter the GitHub token. This is required for private repositories."
+    echo "Create a token at: https://github.com/settings/tokens"
+    echo "Required scope: repo"
     echo ""
-    read -sp "GitHubトークン (入力は非表示): " input_token
+    read -sp "GitHub token (input hidden): " input_token
     echo ""
     TOKEN="${input_token}"
     
     if [ -z "${TOKEN}" ]; then
       echo ""
-      echo "⚠️  警告: トークンが入力されませんでした"
-      read -p "トークンなしで続行しますか？ (y/N): " -n 1 -r
+      echo "Warning: no token was provided."
+      read -p "Continue without a token? (y/N): " -n 1 -r
       echo ""
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "中断しました"
+        echo "Aborted."
         exit 1
       fi
     fi
   fi
 else
-  echo "認証: トークン設定済み ✓ (引数から)"
+  echo "Authentication: token configured (from argument)"
 fi
 
-# 設定確認
+# Confirm the selected settings.
 if [ "${SKIP_CONFIRM}" = false ]; then
   echo ""
-  echo "--- 設定内容 ---"
-  echo "リポジトリ: ${REPO}"
-  echo "保存先: ${DOWNLOAD_DIR}"
-  echo "認証: $([ -n "${TOKEN}" ] && echo "あり" || echo "なし")"
+  echo "--- Configuration ---"
+  echo "Repository: ${REPO}"
+  echo "Download directory: ${DOWNLOAD_DIR}"
+  echo "Authentication: $([ -n "${TOKEN}" ] && echo "configured" || echo "not configured")"
   echo ""
-  read -p "この設定で続行しますか？ (Y/n): " -n 1 -r
+  read -p "Continue with this configuration? (Y/n): " -n 1 -r
   echo ""
   if [[ $REPLY =~ ^[Nn]$ ]]; then
-    echo "中断しました"
+    echo "Aborted."
     exit 1
   fi
 fi
 echo ""
 
-# ダウンロードディレクトリの作成
+# Create the download directory.
 mkdir -p "${DOWNLOAD_DIR}"
 
-# curl共通オプション
+# Shared curl options.
 CURL_OPTS="-L -f -s -S"
 
-# 最新リリースの取得
-echo "最新リリースを取得中..."
+# Fetch the latest release.
+echo "Fetching the latest release..."
 if [ -n "${TOKEN}" ]; then
   RELEASE_INFO=$(curl ${CURL_OPTS} \
     -H "Authorization: Bearer ${TOKEN}" \
@@ -171,31 +171,31 @@ else
     "https://api.github.com/repos/${REPO}/releases/latest" 2>&1)
 fi
 
-# エラーチェック
+# Check for errors.
 if [ $? -ne 0 ]; then
   echo ""
-  echo "❌ エラー: リリース情報の取得に失敗しました"
+  echo "Error: failed to fetch release information."
   echo ""
   echo "${RELEASE_INFO}"
   echo ""
-  echo "考えられる原因:"
-  echo "  1. リポジトリにリリースが存在しない"
-  echo "  2. GITHUB_TOKENが無効または権限不足"
-  echo "  3. リポジトリ名が間違っている"
+  echo "Possible causes:"
+  echo "  1. No release exists in the repository."
+  echo "  2. GITHUB_TOKEN is invalid or lacks the required permissions."
+  echo "  3. The repository name is incorrect."
   echo ""
-  echo "トークンの作成方法:"
+  echo "Create a token at:"
   echo "  https://github.com/settings/tokens"
-  echo "  必要な権限: repo (プライベートリポジトリの場合)"
+  echo "  Required scope: repo (for private repositories)"
   exit 1
 fi
 
-# リリース情報のパース（jqがあれば使用、なければgrep）
+# Parse the release information with jq if available, otherwise fall back to grep.
 if command -v jq &> /dev/null; then
   DOWNLOAD_URL=$(echo "${RELEASE_INFO}" | jq -r '.assets[0].url')
   TAG_NAME=$(echo "${RELEASE_INFO}" | jq -r '.tag_name')
   ASSET_NAME=$(echo "${RELEASE_INFO}" | jq -r '.assets[0].name')
 else
-  # assetsセクションのURLを取得（リリース本体のURLではなく）
+  # Extract the asset URL rather than the release page URL.
   DOWNLOAD_URL=$(echo "${RELEASE_INFO}" | grep -o '"url"[[:space:]]*:[[:space:]]*"https://api.github.com/repos/[^"]*releases/assets/[0-9]*"' | head -1 | grep -o 'https://[^"]*')
   TAG_NAME=$(echo "${RELEASE_INFO}" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
   ASSET_NAME=$(echo "${RELEASE_INFO}" | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*\.tar\.gz"' | head -1 | cut -d'"' -f4)
@@ -203,27 +203,27 @@ fi
 
 if [ -z "${DOWNLOAD_URL}" ] || [ "${DOWNLOAD_URL}" == "null" ]; then
   echo ""
-  echo "❌ エラー: ダウンロードURLが見つかりません"
+  echo "Error: download URL was not found."
   echo ""
-  echo "リリース情報:"
+  echo "Release information:"
   echo "${RELEASE_INFO}" | head -20
   echo ""
-  echo "手動でダウンロードする場合:"
+  echo "To download manually:"
   echo "  https://github.com/${REPO}/releases"
   exit 1
 fi
 
-echo "リリース: ${TAG_NAME}"
-echo "ファイル: ${ASSET_NAME}"
+echo "Release: ${TAG_NAME}"
+echo "File: ${ASSET_NAME}"
 echo ""
 
-# アーカイブのダウンロード（GitHub API経由で認証付き）
-echo "証明書をダウンロード中..."
+# Download the archive with GitHub API authentication when a token is available.
+echo "Downloading certificates..."
 ARCHIVE_FILE="${DOWNLOAD_DIR}/certs.tar.gz"
 
 if [ -n "${TOKEN}" ]; then
-  # プライベートリポジトリ: API経由で2段階ダウンロード
-  # 1. リダイレクトURLを取得
+  # Private repository: perform a two-step download through the API.
+  # 1. Get the redirect URL.
   REDIRECT_URL=$(curl -sI \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Accept: application/octet-stream" \
@@ -232,87 +232,87 @@ if [ -n "${TOKEN}" ]; then
   
   if [ -z "${REDIRECT_URL}" ]; then
     echo ""
-    echo "❌ エラー: ダウンロードURLの取得に失敗しました"
-    echo "デバッグ: DOWNLOAD_URL=${DOWNLOAD_URL}"
+    echo "Error: failed to retrieve the download URL."
+    echo "Debug: DOWNLOAD_URL=${DOWNLOAD_URL}"
     exit 1
   fi
   
-  echo "リダイレクトURL取得完了"
+  echo "Redirect URL retrieved."
   
-  # 2. リダイレクト先から直接ダウンロード
+  # 2. Download directly from the redirected location.
   HTTP_CODE=$(curl -L -w "%{http_code}" -o "${ARCHIVE_FILE}" "${REDIRECT_URL}")
   
   if [ "${HTTP_CODE}" -ne 200 ]; then
     echo ""
-    echo "❌ エラー: ダウンロードに失敗しました (HTTP ${HTTP_CODE})"
+    echo "Error: download failed (HTTP ${HTTP_CODE})."
     rm -f "${ARCHIVE_FILE}"
     exit 1
   fi
 else
-  # パブリックリポジトリ: browser_download_urlから直接ダウンロード
+  # Public repository: download directly from browser_download_url.
   BROWSER_URL=$(echo "${RELEASE_INFO}" | grep -o '"browser_download_url": "[^"]*' | head -1 | cut -d'"' -f4)
   
   HTTP_CODE=$(curl -L -w "%{http_code}" -o "${ARCHIVE_FILE}" "${BROWSER_URL}")
   
   if [ "${HTTP_CODE}" -ne 200 ]; then
     echo ""
-    echo "❌ エラー: ダウンロードに失敗しました (HTTP ${HTTP_CODE})"
+    echo "Error: download failed (HTTP ${HTTP_CODE})."
     rm -f "${ARCHIVE_FILE}"
     exit 1
   fi
 fi
 
-# ダウンロードファイルのサイズ確認
+# Verify that the downloaded file is not empty.
 if [ ! -s "${ARCHIVE_FILE}" ]; then
   echo ""
-  echo "❌ エラー: ダウンロードしたファイルが空です"
+  echo "Error: the downloaded file is empty."
   exit 1
 fi
 
-echo "ダウンロード完了: $(ls -lh "${ARCHIVE_FILE}" | awk '{print $5}')"
+echo "Download completed: $(ls -lh "${ARCHIVE_FILE}" | awk '{print $5}')"
 
 
-# アーカイブの展開
-echo "証明書を展開中..."
+# Extract the archive.
+echo "Extracting certificates..."
 tar -xzf "${ARCHIVE_FILE}" -C "${DOWNLOAD_DIR}"
 
 if [ $? -ne 0 ]; then
   echo ""
-  echo "❌ エラー: アーカイブの展開に失敗しました"
-  echo "アーカイブファイル: ${ARCHIVE_FILE}"
+  echo "Error: failed to extract the archive."
+  echo "Archive file: ${ARCHIVE_FILE}"
   echo ""
-  echo "手動で確認:"
+  echo "To inspect it manually:"
   echo "  tar -tzf ${ARCHIVE_FILE}"
   exit 1
 fi
 
-# 展開されたファイルを確認
+# Check the extracted files.
 CERT_FILES=$(find "${DOWNLOAD_DIR}" -type f \( -name "*.crt" -o -name "*.key" \) | wc -l)
 if [ "${CERT_FILES}" -eq 0 ]; then
   echo ""
-  echo "❌ エラー: 証明書ファイルが見つかりません"
-  echo "アーカイブの内容を確認してください: ${ARCHIVE_FILE}"
+  echo "Error: no certificate files were found."
+  echo "Please inspect the archive contents: ${ARCHIVE_FILE}"
   echo ""
-  echo "展開されたファイル:"
+  echo "Extracted files:"
   ls -la "${DOWNLOAD_DIR}"
   exit 1
 fi
 
-# アーカイブファイルの削除
+# Remove the archive file.
 rm -f "${ARCHIVE_FILE}"
 
 echo ""
 echo "==================================="
-echo "ダウンロード完了！"
+echo "Download completed."
 echo "==================================="
-echo "証明書の場所: $(cd "${DOWNLOAD_DIR}" && pwd)"
+echo "Certificate location: $(cd "${DOWNLOAD_DIR}" && pwd)"
 echo ""
-echo "ファイル一覧:"
+echo "Files:"
 ls -lh "${DOWNLOAD_DIR}" | grep -E "\.(crt|key)$" || ls -lh "${DOWNLOAD_DIR}"
 echo ""
-echo "次のステップ:"
-echo "1. ca.crt, client.crt, server.crt を適切な場所にコピー"
-echo "2. ca.key, client.key, server.key を安全に保管"
+echo "Next steps:"
+echo "1. Copy ca.crt, client.crt, and server.crt to the appropriate locations."
+echo "2. Store ca.key, client.key, and server.key securely."
 echo ""
-echo "証明書の確認:"
+echo "Certificate check:"
 echo "  openssl x509 -in ${DOWNLOAD_DIR}/ca.crt -noout -subject -dates"


### PR DESCRIPTION
## Summary
- translate Japanese comments and shell output messages in source scripts to English
- update run.sh and related helper scripts so user-facing output is consistently English
- translate the README to English while preserving the existing structure and guidance

## Validation
- searched the updated source files and README for remaining Japanese text
- checked edited files for editor-reported errors
- fixed Markdown lint issues introduced by placeholder angle brackets in README